### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo contains a [collection of reusable workflows](https://github.com/nmfs-
 First, install the ghactions4r R package:
 ```r
 install.packages("remotes")
-remotes::install_github(nmfs-fish-tools/ghactions4r)
+remotes::install_github("nmfs-fish-tools/ghactions4r")
 ```
 `use_*()` functions in the `ghactions4r` package work like [`use_*()` functions in the `usethis` package](https://github.com/r-lib/usethis#usage).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ghactions4r::use_calc_coverage()
 
 - To update documentation using `devtools::document()`:
 ```r
-ghactions4r::user_update_roxygen_docs()
+ghactions4r::use_update_roxygen_docs()
 ```
 
 - To update code styling using `styler::style_pkg()`:


### PR DESCRIPTION
- `remotes::install_github(nmfs-fish-tools/ghactions4r)` from the README does not work, so I added quotation mark around ` "nmfs-fish-tools/ghactions4r" `.
- Fixed the typo in `ghactions4r::user_update_roxygen_docs()` to `ghactions4r::use_update_roxygen_docs()`.