### PR TITLE
add full and standard matrix options for r cmd check

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^\.github$
 ^LICENSE\.md$
+^github$

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: 'nmfs-fish-tools/ghactions4r'
-        ref: 'r-cmd-check'
+        ref: 'main'
     - name: check path
       run: |
         ls -r

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -4,11 +4,43 @@
 
 on:
   workflow_call:
+    inputs:
+      use_full_build_matrix:
+        required: false
+        type: boolean
 
 name: R-CMD-check
-
 jobs:
+  matrix_prep:
+  # Determine the build matrix (OS and versions of R)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: 'nmfs-fish-tools/ghactions4r'
+        ref: 'r-cmd-check'
+    - name: check path
+      run: |
+        ls -r
+        pwd
+    - id: set-matrix
+      run: |
+        if ${{ inputs.use_full_build_matrix }} == 'true';
+        then
+          JSON=$(cat ./github/matrix_includes_full.json)
+        else
+          JSON=$(cat ./github/matrix_includes_standard.json)
+        fi
+        # the following lines are only required for multi line json
+        JSON="${JSON//'%'/'%25'}"
+        JSON="${JSON//$'\n'/'%0A'}"
+        JSON="${JSON//$'\r'/'%0D'}"
+        echo "::set-output name=matrix::$JSON"
+
   R-CMD-check:
+    needs: matrix_prep
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -16,13 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: windows-latest, r: 'oldrel-1'}
-          - {os: windows-latest, r: 'oldrel-2'}
-
+        config: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/R/use_r_workflows.R
+++ b/R/use_r_workflows.R
@@ -1,9 +1,17 @@
 #' Use workflow to run r cmd check on linux, mac, and windows gh actions
+#' @param use_full_build_matrix Run r cmd check with two older versions of r in
+#'   addition to the three runs that use the release version.
 #' @export
-use_r_cmd_check <- function() {
-  usethis::use_github_action("call-r-cmd-check.yml",
-    url = "https://raw.githubusercontent.com/nmfs-fish-tools/ghactions4r/main/inst/templates/call-r-cmd-check.yml",
-  )
+use_r_cmd_check <- function(use_full_build_matrix = FALSE) {
+  if(use_full_build_matrix) {
+    usethis::use_github_action("call-r-cmd-check.yml",
+      url = "https://raw.githubusercontent.com/nmfs-fish-tools/ghactions4r/main/inst/templates/call-r-cmd-check-full.yml",
+    )
+  } else {
+    usethis::use_github_action("call-r-cmd-check.yml",
+      url = "https://raw.githubusercontent.com/nmfs-fish-tools/ghactions4r/main/inst/templates/call-r-cmd-check.yml",
+    )
+  }
 }
 
 #' workflow for calculating code coverage

--- a/github/matrix_includes_full.json
+++ b/github/matrix_includes_full.json
@@ -1,0 +1,23 @@
+[
+  {
+    "os":"windows-latest",
+    "r":"release"
+  },
+  {
+    "os":"macOS-latest",
+    "r":"release"
+  },
+  {
+    "os":"ubuntu-latest",
+    "r":"release",
+    "rspm":"https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+  },
+  {
+    "os":"windows-latest",
+    "r":"oldrel-1"
+  }, 
+  {
+    "os":"windows-latest",
+    "r":"oldrel-2"
+  }
+]

--- a/github/matrix_includes_standard.json
+++ b/github/matrix_includes_standard.json
@@ -1,0 +1,15 @@
+[
+  {
+    "os":"windows-latest",
+    "r":"release"
+  },
+  {
+    "os":"macOS-latest",
+    "r":"release"
+  },
+  {
+    "os":"ubuntu-latest",
+    "r":"release",
+    "rspm":"https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+  }
+]

--- a/inst/templates/call-r-cmd-check-full.yml
+++ b/inst/templates/call-r-cmd-check-full.yml
@@ -1,0 +1,15 @@
+# Run r cmd check
+name: call-r-cmd-check
+# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+# The default build trigger is to run the action on every push and pull request, for any branch
+  push:
+  pull_request:
+  # To run the default repository branch weekly on sunday, uncomment the following 2 lines
+  #schedule:
+    #- cron: '0 0 * * 0'
+jobs:
+  call-workflow:
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+    with:
+      use_full_build_matrix: true


### PR DESCRIPTION
This addresses #11. Unfortunately, the solution wasn't as simple as adding an if statement, as I had hoped it would be. Instead, the build matrices were specified in separate JSON files and read in as a job before R cmd check (part of the workflow file. We could potentially write out the JSON directly in the workflow yaml file, but it could look messy.

A reference on this idea: https://www.cynkra.com/blog/2020-12-23-dynamic-gha/

I ran the workflow on SSMSE. [Standard build run](https://github.com/nmfs-fish-tools/SSMSE/actions/runs/1742573020), [Full build run](https://github.com/nmfs-fish-tools/SSMSE/actions/runs/1742669931) . Note that the last commit changes a branch reference from the feature branch to main, so it will not run now as-is.

Note that I think the R code will need to be tested after merging into main, as it references the main branch (although I could change the reference to the feature branch temporarily to make sure it works).