### PR TITLE
feat, #20: add option to not cache pkgs

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -8,6 +8,10 @@ on:
       use_full_build_matrix:
         required: false
         type: boolean
+      cache_pkgs:
+        required: false
+        default: true
+        type: boolean
 
 name: R-CMD-check
 jobs:
@@ -71,7 +75,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && steps.cache_pkgs == true
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}


### PR DESCRIPTION
Addresses #20.

This adds an option to not cache packages on ubuntu and mac when running the r cmd check workflow. By default, the functionality remains the same (pkgs are cached).

Note that although I thought this was needed for FIMS, it now seems that FIMS was able to install tmb just fine, so it may have been a temporary hiccup. Still, I could see this a useful feature, in case someone explicitly does not want to catch pkgs and in case we run into this issue in the future with FIMS. I think I have seen this issue in other pkgs that rely on TMB, e.g., VAST.

To test this, I tried it out on a branch of FIMS using the option to not cache pkgs, and it worked as expected. [gh actions log](https://github.com/NOAA-FIMS/FIMS/runs/5662699357?check_suite_focus=true). This PR runs call-r-cmd-check and shows the default, where R pkgs are cached. 

Example of how to use this: 

```yaml
# Run r cmd check
name: call-r-cmd-check
# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
on:
  push:
jobs:
  call-workflow:
    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@k-doering-NOAA-patch-2
    with:
      cache_pkgs: false
```