### PR TITLE
Issue 24: make workflow error if styler errors

### DIFF
--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -53,7 +53,12 @@ jobs:
           echo "::set-output name=msg::${last_commit_msg}"
 
       - name: Style
-        run: Rscript -e 'styler::style_pkg()'
+        run: | 
+          results <- styler::style_pkg()
+          if(any(is.na(results[["changed"]])) {
+            stop("Styler through an error")
+          }
+        shell: Rscript {0}
 
       - name: Document
         run: Rscript -e 'roxygen2::roxygenise()'
@@ -70,7 +75,12 @@ jobs:
         shell: Rscript {0}
 
       - name: Style again, just in case
-        run: Rscript -e 'styler::style_pkg()'
+        run: | 
+          results <- styler::style_pkg()
+          if(any(is.na(results[["changed"]])) {
+            stop("Styler through an error")
+          }
+        shell: Rscript {0}
 
       - name: Document again, just in case
         run: |

--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -56,7 +56,7 @@ jobs:
         run: | 
           results <- styler::style_pkg()
           if(any(is.na(results[["changed"]])) {
-            stop("Styler through an error")
+            stop("styler threw an error")
           }
         shell: Rscript {0}
 
@@ -78,7 +78,7 @@ jobs:
         run: | 
           results <- styler::style_pkg()
           if(any(is.na(results[["changed"]])) {
-            stop("Styler through an error")
+            stop("styler threw an error")
           }
         shell: Rscript {0}
 

--- a/.github/workflows/style-r-code.yml
+++ b/.github/workflows/style-r-code.yml
@@ -35,7 +35,7 @@ jobs:
           results <- styler::style_pkg()
           # error if styler failed on any files
           if(any(is.na(results[["changed"]])) {
-            stop("Styler through an error")
+            stop("styler threw an error")
           }
         shell: Rscript {0}
         

--- a/.github/workflows/style-r-code.yml
+++ b/.github/workflows/style-r-code.yml
@@ -31,7 +31,13 @@ jobs:
           echo "::set-output name=msg::${last_commit_msg}"
 
       - name: Style
-        run: Rscript -e 'styler::style_pkg()'
+        run: | 
+          results <- styler::style_pkg()
+          # error if styler failed on any files
+          if(any(is.na(results[["changed"]])) {
+            stop("Styler through an error")
+          }
+        shell: Rscript {0}
         
       - name: Create Pull Request
         if: ${{ !contains(steps.commit-msg.outputs.msg, 'style_pkg') }}


### PR DESCRIPTION
Addresses #24. Should make the workflow fail if styler fails.

I tested the following code locally, but have not tested the github action. I can test the github action if it seems necessary.

```r
# in a cloned R pkg repo (r4ss), I added bad syntax to one of the R files.
# then ran:
test <- styler::style_pkg() # test is a data.frame with 2 columns
any(is.na(test[["changed"]])) # made sure is TRUE when there was an error.
```

