### PR TITLE
update call-doc-and-style-r workflow to style vignettes

### DIFF
--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -1,11 +1,12 @@
 # document and style  using reusable workflow
 on:
-  workflow_dispatch:
+  # workflow_dispatch:
   push:
-    branches: [main]
+    # branches: [main]
     paths: 
       - 'R/**'
       - 'tests/**'
+      - 'vignettes/**'
 name: call-doc-and-style-r
 jobs:
   call-workflow:

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -1,6 +1,6 @@
 # document and style  using reusable workflow
 on:
-  # workflow_dispatch:
+  workflow_dispatch:
   push:
     # branches: [main]
     paths: 

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -1,8 +1,7 @@
 # document and style  using reusable workflow
 on:
-  workflow_dispatch:
   push:
-    # branches: [main]
+    branches: [main]
     paths: 
       - 'R/**'
       - 'tests/**'


### PR DESCRIPTION
This PR addresses issue #51. Now the workflow runs on each push to the main branch and styles the files under the vignettes/ folder. Passed GHA tests can be found here: https://github.com/nmfs-fish-tools/ghactions4r/actions/runs/3331572011/jobs/5511465778#step:10:22.