### PR TITLE
Add spell check

### DIFF
--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -1,0 +1,10 @@
+# run devtools::spell_check()
+name: call-spell-check
+# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+# this workflow runs on pushing to any branch or manually.
+  push:
+  workflow_dispatch:
+jobs:
+  call-workflow:
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@add-spell-check

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -4,8 +4,6 @@ name: call-spell-check
 on:
 # this workflow runs on pushing to main, pull requests to main, and manually.
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -4,10 +4,12 @@ name: call-spell-check
 on:
 # this workflow runs on pushing to main, pull requests to main, and manually.
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@add-spell-check
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@main

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -4,7 +4,11 @@ name: call-spell-check
 on:
 # this workflow runs on pushing to main, pull requests to main, and manually.
   push:
-  pull_request: [main]
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 jobs:
   call-workflow:

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -2,8 +2,9 @@
 name: call-spell-check
 # on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
-# this workflow runs on pushing to any branch or manually.
+# this workflow runs on pushing to main, pull requests to main, and manually.
   push:
+  pull_request: [main]
   workflow_dispatch:
 jobs:
   call-workflow:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,27 @@
+# check spelling using devtools::spell_check()
+on:
+ workflow_call:
+
+name: run devtools::spell_check
+
+jobs:
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+    
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Install  devtools
+        run: Rscript -e 'install.packages("devtools")'
+
+      - name: Install spelling
+        run: Rscript -e 'install.packages("spelling")'
+
+      - name: spell check
+        run: | 
+          devtools::spell_check()
+        shell: Rscript {0}
+
+#      - name: fail job if any spelling errors are caught

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -21,6 +21,8 @@ jobs:
           results <- spelling::spell_check_package()
           if(nrow(results)>0) {
             print(results)
-            stop("Failing test because spelling errors found.")
+            stop("Spelling errors found.\n", 
+            "Need to ignore some words? Read up on using the WORDLIST file:\n",
+            "https://docs.ropensci.org/spelling/reference/wordlist.html")
           }
         shell: Rscript {0}

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,4 +1,4 @@
-# check spelling using devtools::spell_check()
+# check spelling using spelling::spell_check_package()
 on:
  workflow_call:
 
@@ -17,7 +17,10 @@ jobs:
         run: Rscript -e 'install.packages("spelling")'
 
       - name: spell check
-        run: spelling::spell_check_package()
+        run: |
+          results <- spelling::spell_check_package()
+          if(nrow(results)>0) {
+            print(results)
+            stop("Failing test because spelling errors found.")
+          }
         shell: Rscript {0}
-
-#      - name: fail job if any spelling errors are caught

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -13,15 +13,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
 
-      - name: Install  devtools
-        run: Rscript -e 'install.packages("devtools")'
-
       - name: Install spelling
         run: Rscript -e 'install.packages("spelling")'
 
       - name: spell check
-        run: | 
-          devtools::spell_check()
+        run: spelling::spell_check_package()
         shell: Rscript {0}
 
 #      - name: fail job if any spelling errors are caught

--- a/R/use_r_workflows.R
+++ b/R/use_r_workflows.R
@@ -174,3 +174,18 @@ use_build_deploy_bookdown <- function(
   writeLines(gha, path_to_yml)
   return(path_to_yml)
 }
+
+#' use workflow to run spelling::spell_check_package()
+#' @template workflow_name
+#' @return The path to the new github action file.
+#' @export
+use_style_r_code <- function(workflow_name = "call-spell-check.yml") {
+  check_workflow_name(workflow_name)
+  usethis::use_github_action("call-spell-check.yml",
+    save_as = workflow_name,
+    url = "https://raw.githubusercontent.com/nmfs-fish-tools/ghactions4r/main/inst/templates/call-spell-check.yml"
+  )
+  path_to_yml <- file.path(".github", "workflows", workflow_name)
+  return(path_to_yml)
+}
+

--- a/R/use_r_workflows.R
+++ b/R/use_r_workflows.R
@@ -179,7 +179,7 @@ use_build_deploy_bookdown <- function(
 #' @template workflow_name
 #' @return The path to the new github action file.
 #' @export
-use_style_r_code <- function(workflow_name = "call-spell-check.yml") {
+use_spell_check <- function(workflow_name = "call-spell-check.yml") {
   check_workflow_name(workflow_name)
   usethis::use_github_action("call-spell-check.yml",
     save_as = workflow_name,

--- a/README.md
+++ b/README.md
@@ -92,5 +92,3 @@ Additional details are available in the [NOAA FIT Contributing Guide](https://no
 <img src="https://raw.githubusercontent.com/nmfs-general-modeling-tools/nmfspalette/main/man/figures/noaa-fisheries-rgb-2line-horizontal-small.png" height="75" alt="NOAA Fisheries">
 
 [U.S. Department of Commerce](https://www.commerce.gov/) | [National Oceanographic and Atmospheric Administration](https://www.noaa.gov) | [NOAA Fisheries](https://www.fisheries.noaa.gov/)
-
-splling errr

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ ghactions4r::use_update_pkgdown()
 ghactions4r::use_build_deploy_bookdown()
 ```
 
+- To spell check an R package:
+```r
+ghactions4r::use_spell_check()
+```
+
 Commit and push the files generated up to github, making the github actions available for the repository of the R package.
 
 The templates these functions generate can also be [viewed](https://github.com/nmfs-fish-tools/ghactions4r/tree/main/inst/templates) for reference.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,5 @@ Additional details are available in the [NOAA FIT Contributing Guide](https://no
 <img src="https://raw.githubusercontent.com/nmfs-general-modeling-tools/nmfspalette/main/man/figures/noaa-fisheries-rgb-2line-horizontal-small.png" height="75" alt="NOAA Fisheries">
 
 [U.S. Department of Commerce](https://www.commerce.gov/) | [National Oceanographic and Atmospheric Administration](https://www.noaa.gov) | [NOAA Fisheries](https://www.fisheries.noaa.gov/)
+
+splling errr

--- a/inst/templates/call-spell-check.yml
+++ b/inst/templates/call-spell-check.yml
@@ -1,0 +1,15 @@
+# run devtools::spell_check()
+name: call-spell-check
+# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+# this workflow runs on pushing to main, pull requests to main, and manually.
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  call-workflow:
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@main

--- a/tests/testthat/test-use_r_workflows.R
+++ b/tests/testthat/test-use_r_workflows.R
@@ -95,3 +95,8 @@ test_that("use_build_deploy_bookdown() works", {
   expect_length(grep("bookdown_output_dir:", txt), 1)
   expect_length(grep("deployment_dir:", txt), 1)
 })
+
+test_that("use_spell_check() works", {
+  use_spell_check()
+  expect_true(file.exists(".github/workflows/call-spell-check.yml"))
+})


### PR DESCRIPTION
Addresses #36, adding a workflow for running `devtools::spell_check()` (which is a wrapper for `spelling::spell_chack_packages()` and the actual function that is run in the gha). The workflow will fail and provide information on the misspelled words, as well as a link on how to setup and use the WORDLIST.

Thanks @iantaylor-NOAA for the suggestion! I will merge so the workflow is available, and it can be set up using the function `use_spell_check()`. Feel free to submit followup issues.