### PR TITLE
feat: add option for PAT to style-and-doc-r.yml

### DIFF
--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -14,6 +14,9 @@
 # Need help debugging build failures? Open an issue at https://github.com/nmfs-fish-tools/ghactions4r/issues
 on:
  workflow_call:
+   secrets:
+     PAT:
+       required: false
    inputs:
      run-rm_dollar_sign:
        required: false
@@ -31,8 +34,11 @@ jobs:
     name: doc and style
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PAT }}
     steps:
+      - name: setup env using GITHUB_TOKEN, if no pat
+        if: env.GITHUB_PAT == ''
+        run: echo "GITHUB_PAT=${{ secrets.GITHUB_TOKEN}}" >> "$GITHUB_ENV"
       - name: checkout, make changes and submit as pr on new branch
         if: inputs.commit-directly == false
         uses: actions/checkout@v3
@@ -120,6 +126,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           commit-message: 'style and docs: run devtools::document() and styler::style_pkg()'
+          token: ${{ env.GITHUB_PAT }}
           branch: style-doc-code
           title: 'Style code and document'
           body: |

--- a/inst/templates/call-doc-and-style-r.yml
+++ b/inst/templates/call-doc-and-style-r.yml
@@ -9,3 +9,12 @@ on:
 jobs:
   call-workflow:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main
+    # uncomment secrets below to allow the pull request created from this workflow to trigger github action runs.
+    # note a PAT can trigger recursive runs, so should be used with caution. See github documentation for more info:
+    # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+    # Need to add a personal access token as a secret to your github repository.
+    # can change secrets.API to a different 
+    # secret name if it is named differently in the repository.
+    #secrets:
+    #  PAT: ${{ secrets.PAT }}
+  


### PR DESCRIPTION
Addresses #85 . Add ability to add a PAT to the doc-and-style-r workflows, which would allow pull requests or commits created by the run to trigger new github action runs (without a PAT, no github action runs will be started by pull requests or commits created).

No breaking changes to existing functionality.

Passing in a token can be done by using a workflow like:
```yml
# document and style using reusable workflow
# This workflow runs devtools::document and styler::style_active_package(), then opens a pull request to the branch
# That started the workflow with the changes
name: call-doc-and-style-r
# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
on:
  push:
    branches: [main, master]
jobs:
  call-workflow:
    uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main
    # note a PAT can trigger recursive runs, so should be used with caution. See github documentation for more info:
    # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
    # Need to add a personal access token as a secret to your github repository.
    # can change secrets.API to a different 
    # secret name if it is named differently in the repository.
    secrets:
      PAT: ${{ secrets.PAT }}
```

as comments in the example workflow show, care must be taken to not cause recursive runs when using a PAT.

This was tested using the branch: https://github.com/nmfs-fish-tools/ghactions4r/tree/feat-pat-style-doc 

I tested:

- opening a PR without a PAT (existing feature)
- opening a PR with a PAT (new feature)
- Committing directly without a PAT (existing feature)

Committing directly with a PAT likely results in recursive runs, so shouldn't be used.

Additional testing will be done on opening a PR with a PAT for use in https://github.com/noaa-fims/fims