### PR TITLE
#90, fix: add apt-get update

### DIFF
--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -51,6 +51,7 @@ jobs:
       
       - name: Install curl dependency
         run: |
+          sudo apt-get update
           sudo apt-get install libcurl4-openssl-dev
 
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
Add `sudo apt-get update` before installing curl dependency. Thanks @iantaylor-NOAA for figuring this out!

Resolves #90