### PR TITLE
Add depends_on_tmb option to r cmd check. #106

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: number
         default: 360
+      depends_on_tmb:
+        required: false
+        type: boolean
+        default: false
 
 name: R-CMD-check
 jobs:
@@ -72,6 +76,12 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+
+      - name: If dependent on TMB, install Matrix from source for windows and mac
+        if: inputs.depends_on_tmb == true && runner.os != 'Linux'
+        run: install.packages("Matrix", type = "source")
+        shell: Rscript {0}
+
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/tests/testthat/_snaps/use_r_workflows.md
+++ b/tests/testthat/_snaps/use_r_workflows.md
@@ -38,6 +38,49 @@
       [14] "    with:"                                                                                                                                
       [15] "      use_full_build_matrix: true"                                                                                                        
 
+# use_r_cmd_check() works with full build option and tmb
+
+    Code
+      test
+    Output
+       [1] "# Run r cmd check"                                                                                                                        
+       [2] "name: call-r-cmd-check"                                                                                                                   
+       [3] "# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows"
+       [4] "on:"                                                                                                                                      
+       [5] "# The default build trigger is to run the action on every push and pull request, for any branch"                                          
+       [6] "  push:"                                                                                                                                  
+       [7] "  pull_request:"                                                                                                                          
+       [8] "  # To run the default repository branch weekly on sunday, uncomment the following 2 lines"                                               
+       [9] "  #schedule:"                                                                                                                             
+      [10] "    #- cron: '0 0 * * 0'"                                                                                                                 
+      [11] "jobs:"                                                                                                                                    
+      [12] "  call-workflow:"                                                                                                                         
+      [13] "    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main"                                                             
+      [14] "    with:"                                                                                                                                
+      [15] "      use_full_build_matrix: true"                                                                                                        
+      [16] "      depends_on_tmb: true"                                                                                                               
+
+---
+
+    Code
+      test
+    Output
+       [1] "# Run r cmd check"                                                                                                                        
+       [2] "name: call-r-cmd-check"                                                                                                                   
+       [3] "# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows"
+       [4] "on:"                                                                                                                                      
+       [5] "# The default build trigger is to run the action on every push and pull request, for any branch"                                          
+       [6] "  push:"                                                                                                                                  
+       [7] "  pull_request:"                                                                                                                          
+       [8] "  # To run the default repository branch weekly on sunday, uncomment the following 2 lines"                                               
+       [9] "  #schedule:"                                                                                                                             
+      [10] "    #- cron: '0 0 * * 0'"                                                                                                                 
+      [11] "jobs:"                                                                                                                                    
+      [12] "  call-workflow:"                                                                                                                         
+      [13] "    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main"                                                             
+      [14] "    with:"                                                                                                                                
+      [15] "      depends_on_tmb: true"                                                                                                               
+
 # use_calc_coverage()) works
 
     Code

--- a/tests/testthat/test-use_r_workflows.R
+++ b/tests/testthat/test-use_r_workflows.R
@@ -26,6 +26,24 @@ test_that("use_r_cmd_check() works with full build option", {
   expect_snapshot(test)
 })
 
+test_that("use_r_cmd_check() works with full build option and tmb", {
+  name <- "call-full-build-check.yml"
+  path <- file.path(".github", "workflows", name)
+  use_r_cmd_check(workflow_name = name, use_full_build_matrix = TRUE, depends_on_tmb = TRUE)
+  expect_true(file.exists(path))
+  test <- readLines(path)
+  expect_snapshot(test)
+})
+
+test_that("use_r_cmd_check() works with full build option and tmb", {
+  name <- "call-full-tmb.yml"
+  path <- file.path(".github", "workflows", name)
+  use_r_cmd_check(workflow_name = name, use_full_build_matrix = FALSE, depends_on_tmb = TRUE)
+  expect_true(file.exists(path))
+  test <- readLines(path)
+  expect_snapshot(test)
+})
+
 test_that("use_calc_coverage()) works", {
   use_calc_coverage()
   expect_true(file.exists(".github/workflows/call-calc-coverage.yml"))


### PR DESCRIPTION
This addresses #106.

Basically, it adds an option called `depends_on_tmb` to the `r-cmd-check` workflow that downloads the source version of Matrix on Mac and Windows to solve a complicated issue that affects TMB models. See more details in this [google groups thread](https://groups.google.com/g/tmb-users/c/-GhmuuDP_OQ).

Here's an example workflow that calls r-cmd-check with the `depends_on_tmb` option set to true (note: replace `@main` with `@depends-on-tmb` to test the changes on this branch:

```yml
# Run r cmd check
name: call-r-cmd-check
on:
  push:
jobs:
  call-workflow:
    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
    with:
      depends_on_tmb: true

```