### PR TITLE
Add use-public-rspm = FALSE option to calc coverage.

### DIFF
--- a/.github/workflows/calc-coverage.yml
+++ b/.github/workflows/calc-coverage.yml
@@ -2,6 +2,11 @@
 
 on:
   workflow_call:
+    inputs:
+      use-public-rspm:
+        required: false
+        type: boolean
+        default: true
 
 name: calc-coverage
 
@@ -15,7 +20,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          use-public-rspm: true
+          use-public-rspm: ${{ inputs.use-public-rspm }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/tests/testthat/_snaps/use_r_workflows.md
+++ b/tests/testthat/_snaps/use_r_workflows.md
@@ -81,7 +81,7 @@
       [14] "    with:"                                                                                                                                
       [15] "      depends_on_tmb: true"                                                                                                               
 
-# use_calc_coverage()) works
+# use_calc_coverage() works
 
     Code
       test
@@ -94,6 +94,22 @@
       [6] "jobs:"                                                                                                                                    
       [7] "  call-workflow:"                                                                                                                         
       [8] "    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main"                                                           
+
+# use_calc_coverage() works with use-public-rspm = FALSE
+
+    Code
+      test
+    Output
+       [1] "# call a workflow that runs covr::codecov() to calculate code coverage"                                                                   
+       [2] "name: call-calc_coverage"                                                                                                                 
+       [3] "# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows"
+       [4] "# The default is to run the workflow on every push or pull request to every branch."                                                      
+       [5] "on: [push, pull_request]"                                                                                                                 
+       [6] "jobs:"                                                                                                                                    
+       [7] "  call-workflow:"                                                                                                                         
+       [8] "    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main"                                                           
+       [9] "    with:"                                                                                                                                
+      [10] "      use-public-rspm: false"                                                                                                             
 
 # use_doc_and_style_r() works
 

--- a/tests/testthat/test-use_r_workflows.R
+++ b/tests/testthat/test-use_r_workflows.R
@@ -44,10 +44,18 @@ test_that("use_r_cmd_check() works with full build option and tmb", {
   expect_snapshot(test)
 })
 
-test_that("use_calc_coverage()) works", {
+test_that("use_calc_coverage() works", {
   use_calc_coverage()
   expect_true(file.exists(".github/workflows/call-calc-coverage.yml"))
   test <- readLines(".github/workflows/call-calc-coverage.yml")
+  expect_snapshot(test)
+})
+
+test_that("use_calc_coverage() works with use-public-rspm = FALSE", {
+  workflow_name <- "call-calc-cov-false.yml"
+  use_calc_coverage(workflow_name = workflow_name, use_public_rspm = FALSE)
+  expect_true(file.exists(file.path(".github", "workflows", workflow_name)))
+  test <- readLines(file.path(".github", "workflows", workflow_name))
   expect_snapshot(test)
 })
 


### PR DESCRIPTION
Addresses #110. The purpose is to allow users to specify `use-public-rspm = FALSE` in a workflow. This means that cran (not compiled for linux) packages will be used instead of posit package manager (compiled for linux). This is unlikely to be used, as the runs will be slower; however, there is a matrix bug that affects TMB dependencies that can be fixed by downloading from source instead of compiled packages.

The workflow would look like this:
```yml
# call a workflow that runs covr::codecov() to calculate code coverage
name: call-calc_coverage
# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
# The default is to run the workflow on every push or pull request to every branch.
on: [push, pull_request]
jobs:
  call-workflow:
    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main
    with:
      use-public-rspm: false
```

For testing purposes before this PR is merged in, use the branch `fix-calc-cov` instead of `main`.

@Andrea-Havron-NOAA, when you are back, could you test and see if this solves the failing clustTMB calc coverage workflow?