### PR TITLE
#120: add reusable workflow to check pkgdown builds.

### DIFF
--- a/.github/workflows/build-pkgdown.yml
+++ b/.github/workflows/build-pkgdown.yml
@@ -1,0 +1,36 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  workflow_call:
+
+name: build-pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: build pkgdown
+        run: |
+          Rscript -e 'pkgdown::build_site()'
+     
+      - name: save pkgdown output
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgdown-site
+          path: docs/
+     

--- a/R/use_r_workflows.R
+++ b/R/use_r_workflows.R
@@ -193,6 +193,17 @@ use_update_pkgdown <- function(workflow_name = "call-update-pkgdown.yml") {
   )
 }
 
+#' use workflow in current pkg to check pkgdown site builds.
+#' @template workflow_name
+#' @export
+use_build_pkgdown <- function(workflow_name = "call-build-pkgdown.yml") {
+  check_workflow_name(workflow_name)
+  usethis::use_github_action("call-build-pkgdown.yml",
+    save_as = workflow_name,
+    url = "https://raw.githubusercontent.com/nmfs-fish-tools/ghactions4r/main/inst/templates/call-build-pkgdown.yml"
+  )
+}
+
 #' use workflow in current pkg to run devtools::document() and submit results as a PR
 #' @template workflow_name
 #' @export

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ ghactions4r::use_doc_and_style_r(use_rm_dollar_sign = FALSE)
 ghactions4r::use_update_pkgdown()
 ```
 
+- To check that a pkgdown site builds:
+```r
+ghactions4r::use_build_pkgdown()
+```
+
 - To automatically build and deploy bookdown (to a branch called gh-pages in the same repository) that is in an R package repository:
 ```r
 ghactions4r::use_build_deploy_bookdown()

--- a/inst/templates/call-build-pkgdown.yml
+++ b/inst/templates/call-build-pkgdown.yml
@@ -1,0 +1,15 @@
+# Checks that the pkgdown site builds for a repository.
+# this assumes pkgdown is already set up.
+name: call-build-pkgdown
+# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+# this workflow runs on pushes to main or master or any time a new tag is pushed
+# it also runs everytime a pull request to main or master is opened.
+  push:
+    branches: [main, master]
+    tags: ['*']
+  pull_request:
+    branches: [main, master]
+jobs:
+  call-workflow:
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/build-pkgdown.yml@main

--- a/tests/testthat/test-use_r_workflows.R
+++ b/tests/testthat/test-use_r_workflows.R
@@ -144,6 +144,13 @@ test_that("use_update_pkgdown()) works", {
   expect_snapshot(test)
 })
 
+test_that("use_build_pkgdown()) works", {
+  use_build_pkgdown()
+  expect_true(file.exists(".github/workflows/call-build-pkgdown.yml"))
+  test <- readLines(".github/workflows/call-build-pkgdown.yml")
+  expect_snapshot(test)
+})
+
 test_that("use_update_roxygen_docs() works", {
   use_update_roxygen_docs()
   expect_true(file.exists(".github/workflows/call-update-docs.yml"))


### PR DESCRIPTION
This pull request addresses #120.

@Bai-Li-NOAA this is ready for testing. I think you can use a file like the below to test on a branch.

I did try testing using the file below on the ghactions4r pkgdown site. I broke the pkgdown build, and confirmed that the github action failed. I also confirmed that the html was saved as an artifact for successful runs (these commits were on the check-pkgdown branch, but I have removed them).


```
# Checks that the pkgdown site builds for a repository.
# this assumes pkgdown is already set up.
name: call-build-pkgdown
# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
on:
  push:
jobs:
  call-workflow:
    uses: nmfs-fish-tools/ghactions4r/.github/workflows/build-pkgdown.yml@check-pkgdown
```