### PR TITLE
Update r-cmd-check.yml with linux libraries for R and ss3

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -70,8 +70,6 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get install --only-upgrade libstdc++6
       
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -67,10 +67,9 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: update linux libraries
+        if: matrix.config.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get install --only-upgrade libstdc++6
       
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -65,7 +65,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      
+      - name: update linux libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get install --only-upgrade libstdc++6
+      
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -70,6 +70,8 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get install --only-upgrade libstdc++6
       
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
To get ss3 and r4ss running with the r_cmd_check workflow on a linux machine, the updates in this PR had to be added. These same updates are used in the workflows to update the ss3-user-examples and the ss3-test-models. The second and third lines are linux R specific updates needed for r4ss to work properly, and the fourth line is a gcc library update that ss3 needs to run on a linux machine.