### PR TITLE
add linux libraries for ss3 to update-pkgdown.yml

### DIFF
--- a/.github/workflows/update-pkgdown.yml
+++ b/.github/workflows/update-pkgdown.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: update linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get install --only-upgrade libstdc++6
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
I tested this update with a call to the workflow for r4ss - successful workflow run available [here](https://github.com/r4ss/r4ss/actions/runs/11838370144).

I'm still not sure why there are library mismatches when the ss3 exe is built using the ubuntu-latest runner.