### PR TITLE
Dollar sign within quotations fix

### DIFF
--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -39,6 +39,7 @@ jobs:
       - name: setup env using GITHUB_TOKEN, if no pat
         if: env.GITHUB_PAT == ''
         run: echo "GITHUB_PAT=${{ secrets.GITHUB_TOKEN}}" >> "$GITHUB_ENV"
+
       - name: checkout, make changes and submit as pr on new branch
         if: inputs.commit-directly == false
         uses: actions/checkout@v4

--- a/R/rm_dollar_sign.R
+++ b/R/rm_dollar_sign.R
@@ -74,6 +74,17 @@ rm_dollar_sign <- function(file,
     replacement = replace_no_backtick_in_quotes,
     mod_lines
   )
+  if (allow_recursive) {
+    mod_lines <- recursive_replace(pattern = pattern_no_backtick_in_quotes,
+      replace = replace_no_backtick_in_quotes, lines = mod_lines, max_loops = max_loops)
+} else {
+  if (length(grep(pattern_no_backtick_in_quotes, x = mod_lines)) > 0) {
+    warning(
+      "There are lists in lists in quotes, but allow_recursive = FALSE, so not all",
+      "dollar sign operators were converted."
+    )
+  }
+}
 
   pattern_no_backtick <-
     "([[:alnum:]]|\\.|\\_|\\]|\\(|\\))\\$([[:alnum:]]+)(([[:alnum:]]|\\.|\\_)*)(\\s|[[:punct:]]|$)"
@@ -84,23 +95,8 @@ rm_dollar_sign <- function(file,
     mod_lines
   )
   if (allow_recursive) {
-    # get rid of $ when there are lists in lists.
-    ind <- 1
-    while (length(grep(pattern_no_backtick, x = mod_lines)) > 0 &
-      ind <= max_loops) {
-      ind <- ind + 1
-      mod_lines <- gsub(
-        pattern = pattern_no_backtick,
-        replacement = replace_no_backtick,
-        mod_lines
-      )
-    }
-    if (length(grep(pattern_no_backtick, x = mod_lines)) > 0) {
-      warning(
-        "max_loops was set too low to replace all instances of dollar ",
-        "sign references."
-      )
-    }
+    mod_lines <- recursive_replace(pattern = pattern_no_backtick,
+      replace = replace_no_backtick, lines = mod_lines, max_loops = max_loops)
   } else {
     if (length(grep(pattern_no_backtick, x = mod_lines)) > 0) {
       warning(
@@ -113,4 +109,24 @@ rm_dollar_sign <- function(file,
     writeLines(mod_lines, out_file)
   }
   mod_lines
+}
+
+recursive_replace <- function(pattern, replace, lines, max_loops) {
+  # get rid of $ when there are lists in lists.
+  ind <- 1
+  while (length(grep(pattern, x = lines)) > 0 && ind <= max_loops) {
+    ind <- ind + 1
+    lines <- gsub(
+      pattern = pattern,
+      replacement = replace,
+      lines
+    )
+  }
+  if (length(grep(pattern, x = lines)) > 0) {
+    warning(
+      "max_loops was set too low to replace all instances of dollar ",
+      "sign references in quotes."
+    )
+  }
+  lines
 }

--- a/R/rm_dollar_sign.R
+++ b/R/rm_dollar_sign.R
@@ -71,6 +71,16 @@ rm_dollar_sign <- function(file,
     lines
   )
   # all others not in back ticks
+  # address situations in quotation marks
+  pattern_no_backtick_in_quotes <-
+    '(".*)([[:alnum:]]|\\.|\\_|\\]|\\(|\\))\\$([[:alnum:]]+)(([[:alnum:]]|\\.|\\_)*)(.*")'
+  replace_no_backtick_in_quotes <- "\\1\\2\\[\\[\'\\3\\4\'\\]\\]\\6"
+  mod_lines <- gsub(
+    pattern = pattern_no_backtick_in_quotes,
+    replacement = replace_no_backtick_in_quotes,
+    mod_lines
+  )
+
   pattern_no_backtick <-
     "([[:alnum:]]|\\.|\\_|\\]|\\(|\\))\\$([[:alnum:]]+)(([[:alnum:]]|\\.|\\_)*)(\\s|[[:punct:]]|$)"
   replace_no_backtick <- "\\1\\[\\[\"\\2\\3\"\\]\\]\\5"

--- a/R/rm_dollar_sign.R
+++ b/R/rm_dollar_sign.R
@@ -4,12 +4,6 @@
 #' which we don't often want. This function takes a file and changes all dollar
 #' signs to double brackets with names in quotations instead. Note that this
 #' function will incorrectly convert text enclosed in backticks that includes a dollar sign.
-#' Note also that if a dollar sign is within a text
-#' string enclosed with quotation marks, it will also not convert correctly and
-#' so will exit on error.
-#' (for example, "See test$name" would become
-#' "See test\[\["name"\]\]", which is not parsable R code due to 2 sets of quotation
-#' marks.)
 #' @param file Filename either with full path or relative to working directory.
 #' @param out_file The name or path of a new file to write to. This is by
 #'  default the same as the original file. Set to NULL to avoid writing a new

--- a/man/rm_dollar_sign.Rd
+++ b/man/rm_dollar_sign.Rd
@@ -31,12 +31,6 @@ The dollar sign is convenient to write, but allows for partial matching,
 which we don't often want. This function takes a file and changes all dollar
 signs to double brackets with names in quotations instead. Note that this
 function will incorrectly convert text enclosed in backticks that includes a dollar sign.
-Note also that if a dollar sign is within a text
-string enclosed with quotation marks, it will also not convert correctly and
-so will exit on error.
-(for example, "See test$name" would become
-"See test[["name"]]", which is not parsable R code due to 2 sets of quotation
-marks.)
 }
 \examples{
 test_text <- c(

--- a/tests/testthat/test-rm_dollar_sign.R
+++ b/tests/testthat/test-rm_dollar_sign.R
@@ -19,7 +19,8 @@ test_that("rm dollar sign works", {
     "x$`nameinbacktick`",
     "x$mylist$my_col$YetAnotherCol",
     "x$mylist$my_col$`1_somename`",
-    "x()$my_name <- y$test"
+    "x()$my_name <- y$test",
+    "\"test object$item with additional quoted text\""
   )
   expect_output <- c(
     "x[[\"my_name\"]] <- y[[\"test\"]]",
@@ -31,7 +32,8 @@ test_that("rm dollar sign works", {
     "x[[\"nameinbacktick\"]]",
     "x[[\"mylist\"]][[\"my_col\"]][[\"YetAnotherCol\"]]",
     "x[[\"mylist\"]][[\"my_col\"]][[\"1_somename\"]]",
-    "x()[[\"my_name\"]] <- y[[\"test\"]]"
+    "x()[[\"my_name\"]] <- y[[\"test\"]]",
+    "\"test object[['item']] with additional quoted text\""
   )
   writeLines(test_text, "test_rm_dollar_sign.txt")
   new_text <- rm_dollar_sign(

--- a/tests/testthat/test-rm_dollar_sign.R
+++ b/tests/testthat/test-rm_dollar_sign.R
@@ -20,7 +20,8 @@ test_that("rm dollar sign works", {
     "x$mylist$my_col$YetAnotherCol",
     "x$mylist$my_col$`1_somename`",
     "x()$my_name <- y$test",
-    "\"test object$item with additional quoted text\""
+    "\"test object$item with additional quoted text\"",
+    "\"test object$item1$item2 with additional quoted text and nested list\""
   )
   expect_output <- c(
     "x[[\"my_name\"]] <- y[[\"test\"]]",
@@ -33,7 +34,8 @@ test_that("rm dollar sign works", {
     "x[[\"mylist\"]][[\"my_col\"]][[\"YetAnotherCol\"]]",
     "x[[\"mylist\"]][[\"my_col\"]][[\"1_somename\"]]",
     "x()[[\"my_name\"]] <- y[[\"test\"]]",
-    "\"test object[['item']] with additional quoted text\""
+    "\"test object[['item']] with additional quoted text\"",
+    "\"test object[['item1']][['item2']] with additional quoted text and nested list\""
   )
   writeLines(test_text, "test_rm_dollar_sign.txt")
   new_text <- rm_dollar_sign(


### PR DESCRIPTION
See issue #150.

A fix in rm_dollar_sign.R to change text()$text within quotes (which would normally throw an error because it converted it to text()[["text"]]) to text()[['text']] instead, thereby fixing the issue of multiple double quotes in a line.

Tested locally by using the r4ss function file (get_ss3_exe.r) that originally made me aware of this issue:
https://github.com/r4ss/r4ss/blob/bb679f422ef6aa9189fe99c14375bee00dab2fa1/R/get_ss3_exe.r#L87

To test via GitHub actions I reverted the fixed line in the main branch of r4ss which has `curl::curl_version()[['ssl_version']]` back to `curl::curl_version()$ssl_version` and then ran the updated rm_dollar_sign.R function and had a successful run [here](https://github.com/r4ss/r4ss/actions/runs/12397334797).


