### PR TITLE
#153: add dependabot to keep ghas up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
adds a dependabot file that will let us know when there are new versions of github actions. This should help us keep ghactions4r more up to date without relying on reports that something is broken!