### PR TITLE
Reduce GitHub Token Permissions

### DIFF
--- a/.github/workflows/build-pkgdown.yml
+++ b/.github/workflows/build-pkgdown.yml
@@ -18,6 +18,12 @@ on:
 
 name: build-pkgdown
 
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/calc-coverage.yml
+++ b/.github/workflows/calc-coverage.yml
@@ -13,6 +13,11 @@ on:
 
 name: calc-coverage
 
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   calc-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -27,6 +27,24 @@ on:
        type: boolean
        default: false
 
+# Give the fewest permissions possible. content and pull-requests are necessary.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  contents: write
+  pull-requests: write
+  actions: none
+  attestations: none
+  checks: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 name: style r code with styler
 
 jobs:

--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -32,18 +32,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: none
-  attestations: none
-  checks: none
-  deployments: none
-  id-token: none
-  issues: none
-  discussions: none
-  packages: none
-  pages: none
-  repository-projects: none
-  security-events: none
-  statuses: none
 
 name: style r code with styler
 

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -28,6 +28,11 @@ on:
         type: string
         default: ""
 
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 name: R-CMD-check
 jobs:
   matrix_prep:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -4,6 +4,11 @@ on:
 
 name: run devtools::spell_check
 
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   spell-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-pkgdown.yml
+++ b/.github/workflows/update-pkgdown.yml
@@ -18,6 +18,24 @@ on:
 
 name: update-pkgdown
 
+# Give the fewest permissions possible. content is necessary.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  contents: write
+  pull-requests: none
+  actions: none
+  attestations: none
+  checks: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-pkgdown.yml
+++ b/.github/workflows/update-pkgdown.yml
@@ -22,19 +22,6 @@ name: update-pkgdown
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions:
   contents: write
-  pull-requests: none
-  actions: none
-  attestations: none
-  checks: none
-  deployments: none
-  id-token: none
-  issues: none
-  discussions: none
-  packages: none
-  pages: none
-  repository-projects: none
-  security-events: none
-  statuses: none
 
 jobs:
   pkgdown:


### PR DESCRIPTION
I recently learned that it is possible to be specific about the [permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) and that most workflows don't require that many permissions. Reducing permissions follows the rule of least privilege and reduces the security risk of using GitHub actions (e.g., if a third party action were hacked).

I went through and curated permissions for GitHub tokens in the ghactions4r reusable workflows to the minimum required. I tested all to make sure that they will still run (on the "permissions" branch, and in a separate repository).

Users should not experience any change in functionality from this Pull Request.