### PR TITLE
update templates to use nmfs-ost

### DIFF
--- a/.github/workflows/call-build-pkgdown.yml
+++ b/.github/workflows/call-build-pkgdown.yml
@@ -12,4 +12,4 @@ on:
     branches: [main, master]
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/build-pkgdown.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/build-pkgdown.yml@main

--- a/.github/workflows/call-calc-cov-summaries.yml
+++ b/.github/workflows/call-calc-cov-summaries.yml
@@ -17,4 +17,4 @@ on:
       - main
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-cov-summaries.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main

--- a/.github/workflows/call-create-cov-badge.yml
+++ b/.github/workflows/call-create-cov-badge.yml
@@ -10,4 +10,4 @@ on:
       - main
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/create-cov-badge.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/create-cov-badge.yml@main

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -9,4 +9,4 @@ on:
 name: call-doc-and-style-r
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -14,4 +14,4 @@ name: call-r-cmd-check
 
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -12,4 +12,4 @@ on:
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/spell-check.yml@main

--- a/.github/workflows/call-update-pkgdown.yml
+++ b/.github/workflows/call-update-pkgdown.yml
@@ -10,4 +10,4 @@ on:
     tags: ['*']
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/update-pkgdown.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/update-pkgdown.yml@main

--- a/inst/templates/call-build-pkgdown.yml
+++ b/inst/templates/call-build-pkgdown.yml
@@ -12,4 +12,4 @@ on:
     branches: [main, master]
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/build-pkgdown.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/build-pkgdown.yml@main

--- a/inst/templates/call-calc-cov-summaries.yml
+++ b/inst/templates/call-calc-cov-summaries.yml
@@ -17,4 +17,4 @@ on:
       - main
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-cov-summaries.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main

--- a/inst/templates/call-calc-coverage.yml
+++ b/inst/templates/call-calc-coverage.yml
@@ -5,6 +5,6 @@ name: call-calc_coverage
 on: [push, pull_request]
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/calc-coverage.yml@main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN}}

--- a/inst/templates/call-create-cov-badge.yml
+++ b/inst/templates/call-create-cov-badge.yml
@@ -11,4 +11,4 @@ on:
       - main
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/create-cov-badge.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/create-cov-badge.yml@main

--- a/inst/templates/call-doc-and-style-r.yml
+++ b/inst/templates/call-doc-and-style-r.yml
@@ -6,5 +6,5 @@ on:
     branches: [main, master]
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main
   

--- a/inst/templates/call-r-cmd-check-full.yml
+++ b/inst/templates/call-r-cmd-check-full.yml
@@ -10,6 +10,6 @@ on:
     #- cron: '0 0 * * 0'
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main
     with:
       use_full_build_matrix: true

--- a/inst/templates/call-r-cmd-check.yml
+++ b/inst/templates/call-r-cmd-check.yml
@@ -10,4 +10,4 @@ on:
     #- cron: '0 0 * * 0'
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main

--- a/inst/templates/call-spell-check.yml
+++ b/inst/templates/call-spell-check.yml
@@ -12,4 +12,4 @@ on:
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/spell-check.yml@main

--- a/inst/templates/call-update-pkgdown.yml
+++ b/inst/templates/call-update-pkgdown.yml
@@ -9,4 +9,4 @@ on:
     tags: ['*']
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/update-pkgdown.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/update-pkgdown.yml@main


### PR DESCRIPTION
Due to #159 (ghactions4r moving to nmfs-ost) change the templates so that anyone downloading new workflows in the next few weeks won't need to update their paths.