### PR TITLE
Address 4 issues

### DIFF
--- a/.github/workflows/build-pkgdown.yml
+++ b/.github/workflows/build-pkgdown.yml
@@ -23,6 +23,10 @@ name: build-pkgdown
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions: {}
 
+# Cancel runs happening simultaneously on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pkgdown:

--- a/.github/workflows/calc-cov-summaries.yml
+++ b/.github/workflows/calc-cov-summaries.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   calc-cov-summaries:
     runs-on: ubuntu-latest

--- a/.github/workflows/call-build-pkgdown.yml
+++ b/.github/workflows/call-build-pkgdown.yml
@@ -10,6 +10,12 @@ on:
     tags: ['*']
   pull_request:
     branches: [main, master]
+
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/build-pkgdown.yml@main

--- a/.github/workflows/call-calc-cov-summaries.yml
+++ b/.github/workflows/call-calc-cov-summaries.yml
@@ -15,6 +15,12 @@ on:
       - opened
     branches:
       - main
+
+# limits permisions to write, as the common use case is for pull requests;
+# this means certain options may not work, but makes the workflow more secure
+permissions:
+  pull-requests: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main

--- a/.github/workflows/call-create-cov-badge.yml
+++ b/.github/workflows/call-create-cov-badge.yml
@@ -8,6 +8,12 @@ on:
   push:
     branches:
       - main
+
+# limits permisions to write, which is the minimum permissions needed to create
+# the coverage badge.
+permissions:
+  contents: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/create-cov-badge.yml@main

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -1,4 +1,6 @@
 # document and style  using reusable workflow
+name: call-doc-and-style-r
+
 on:
   push:
     branches: [main]
@@ -6,7 +8,13 @@ on:
       - 'R/**'
       - 'tests/**'
       - 'vignettes/**'
-name: call-doc-and-style-r
+
+# Give the fewest permissions possible. content and pull-requests are necessary.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -12,6 +12,11 @@ on:
     - cron: '0 0 * * 0'
 name: call-r-cmd-check
 
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/spell-check.yml@main

--- a/.github/workflows/call-update-pkgdown.yml
+++ b/.github/workflows/call-update-pkgdown.yml
@@ -8,6 +8,12 @@ on:
   push:
     branches: [main, master]
     tags: ['*']
+
+# Give the fewest permissions possible. content is necessary.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  contents: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/update-pkgdown.yml@main

--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -33,6 +33,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Cancel runs happening simultaneously on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 name: style r code with styler
 
 jobs:

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -37,6 +37,11 @@ on:
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions: {}
 
+# Cancel runs happening simultaneously on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 name: R-CMD-check
 jobs:
   matrix_prep:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -9,6 +9,11 @@ name: run devtools::spell_check
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions: {}
 
+# Cancel runs happening simultaneously on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spell-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-pkgdown.yml
+++ b/.github/workflows/update-pkgdown.yml
@@ -23,6 +23,11 @@ name: update-pkgdown
 permissions:
   contents: write
 
+# Cancel runs happening simultaneously on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest

--- a/R/input_checks.R
+++ b/R/input_checks.R
@@ -3,6 +3,7 @@
 #' Check the workflow name is formatted correctly
 #'
 #' Basically check that it is a filename that ends in .yml
+#' @noRd
 #' @template workflow_name
 check_workflow_name <- function(workflow_name) {
   stopifnot(is.character(workflow_name))
@@ -14,6 +15,7 @@ check_workflow_name <- function(workflow_name) {
 
 #' Validate additional arguments for R functions
 #'
+#' @noRd
 #' @inheritParams use_r_cmd_check
 validate_additional_args <- function(additional_args) {
   if (!is.null(additional_args)) {

--- a/R/input_checks.R
+++ b/R/input_checks.R
@@ -10,7 +10,7 @@ check_workflow_name <- function(workflow_name) {
   stopifnot(length(workflow_name) == 1)
   get_ext <- grep("\\.yml$", workflow_name)
   stopifnot(isTRUE(length(get_ext) == 1))
-  return(invisible(workflow_name))
+  invisible(workflow_name)
 }
 
 #' Validate additional arguments for R functions
@@ -31,4 +31,5 @@ validate_additional_args <- function(additional_args) {
       cli::cli_abort("All values in {.var additional_args} must be character vectors.")
     }
   }
+  invisible(additional_args)
 }

--- a/R/use_r_workflows.R
+++ b/R/use_r_workflows.R
@@ -123,6 +123,7 @@ use_calc_cov_summaries <- function(
     "https://raw.githubusercontent.com/nmfs-ost/ghactions4r/main/inst/templates/.octocov.yml",
     save_as = ".octocov.yml"
   )
+  invisible(workflow_name)
 }
 
 
@@ -152,6 +153,7 @@ use_calc_coverage <- function(workflow_name = "call-calc-coverage.yml", use_publ
     )
     writeLines(gha, path_to_yml)
   }
+  invisible(workflow_name)
 }
 
 
@@ -195,7 +197,7 @@ use_create_cov_badge <- function(workflow_name = "call-create-cov-badge.yml", us
   cli::cli_alert_info("Copy and paste the following into your readme for a badge, replacing <OWNER> and <REPO> for your GitHub repository location:")
   cli::cli_alert_info("{.code {badge_code}}")
 
-  return(workflow_name)
+  invisible(workflow_name)
 }
 
 
@@ -338,6 +340,8 @@ use_doc_and_style_r <- function(workflow_name = "call-doc-and-style-r.yml",
   }
   writeLines(gha, path_to_yml)
   usethis::use_git_ignore(ignores = "*.rds", directory = file.path(".github"))
+  
+  invisible(workflow_name)
 }
 
 #' Creates a workflow in current R package to update an existing pkgdown GitHub pages site
@@ -376,6 +380,8 @@ use_update_pkgdown <- function(workflow_name = "call-update-pkgdown.yml",
     add_args(workflow_name = workflow_name, additional_args = additional_args)
   }
   cli::cli_alert_info("New to pkgdown? Follow these instructions to set up pkgdown on GitHub Pages {.url https://noaa-fisheries-integrated-toolbox.github.io/resources/noaa%20resources/NOAA-pkgdown/}.")
+
+  invisible(workflow_name)
 }
 
 #' use workflow in current pkg to check pkgdown site builds.
@@ -416,11 +422,11 @@ use_build_pkgdown <- function(workflow_name = "call-build-pkgdown.yml", addition
     add_args(workflow_name = workflow_name, additional_args = additional_args)
   }
   cli::cli_alert_info("New to pkgdown? Follow these instructions to set up pkgdown on GitHub Pages {.url https://noaa-fisheries-integrated-toolbox.github.io/resources/noaa%20resources/NOAA-pkgdown/}.")
+  invisible(workflow_name)
 }
 
 #' use workflow to run spelling::spell_check_package()
 #' @template workflow_name
-#' @return The path to the new github action file.
 #' @export
 use_spell_check <- function(workflow_name = "call-spell-check.yml") {
   check_workflow_name(workflow_name)
@@ -430,5 +436,5 @@ use_spell_check <- function(workflow_name = "call-spell-check.yml") {
   )
   path_to_yml <- file.path(".github", "workflows", workflow_name)
   cli::cli_alert_info("New to spelling::spell_check_package()? Learn more at {.url https://docs.ropensci.org/spelling/#spell-check-a-package}")
-  return(path_to_yml)
+  invisible(workflow_name)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,6 +5,7 @@
 #'   automatically. Default is NULL.
 #' @param prev_line An integer specifying the line number in txt where the arguments
 #'   should be added. If NULL, the function determines this value automatically. Default is NULL.
+#' @noRd
 add_args <- function(workflow_name, additional_args, txt = NULL, prev_line = NULL) {
   path_to_yml <- file.path(".github", "workflows", workflow_name)
   if (is.null(txt) | is.null(prev_line)) {
@@ -37,6 +38,7 @@ add_args <- function(workflow_name, additional_args, txt = NULL, prev_line = NUL
 #' @param uses_line text that includes "uses: "
 #' @param gha The workflow file that has been read in using readLines
 #' @return The modified workflow file
+#' @noRd
 add_public_rspm_false <- function(uses_line, gha) {
   uses_line <- grep(
     uses_line,
@@ -54,6 +56,7 @@ add_public_rspm_false <- function(uses_line, gha) {
 #' @param uses_line text that includes "uses: "
 #' @param gha The workflow file that has been read in using readLines
 #' @return The modified workflow file
+#' @noRd
 add_quarto_true <- function(uses_line, gha) {
   uses_line <- grep(
     uses_line,

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,6 +32,7 @@ add_args <- function(workflow_name, additional_args, txt = NULL, prev_line = NUL
     }
   }
   writeLines(txt, path_to_yml)
+  invisible(workflow_name)
 }
 
 #' Add public rspm is false option to workflows.

--- a/inst/templates/call-build-pkgdown.yml
+++ b/inst/templates/call-build-pkgdown.yml
@@ -10,6 +10,12 @@ on:
     tags: ['*']
   pull_request:
     branches: [main, master]
+
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/build-pkgdown.yml@main

--- a/inst/templates/call-calc-cov-summaries.yml
+++ b/inst/templates/call-calc-cov-summaries.yml
@@ -15,6 +15,12 @@ on:
       - opened
     branches:
       - main
+      
+# limits permisions to write, as the common use case is for pull requests;
+# this means certain options may not work, but makes the workflow more secure
+permissions:
+  pull-requests: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main

--- a/inst/templates/call-create-cov-badge.yml
+++ b/inst/templates/call-create-cov-badge.yml
@@ -9,6 +9,12 @@ on:
   push:
     branches:
       - main
+
+# limits permisions to write, which is the minimum permissions needed to create
+# the coverage badge.
+permissions:
+  contents: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/create-cov-badge.yml@main

--- a/inst/templates/call-doc-and-style-r.yml
+++ b/inst/templates/call-doc-and-style-r.yml
@@ -4,6 +4,13 @@ name: call-doc-and-style-r
 on:
   push:
     branches: [main, master]
+
+# Give the fewest permissions possible. content and pull-requests are necessary.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main

--- a/inst/templates/call-r-cmd-check-full.yml
+++ b/inst/templates/call-r-cmd-check-full.yml
@@ -8,6 +8,12 @@ on:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines
   #schedule:
     #- cron: '0 0 * * 0'
+
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main

--- a/inst/templates/call-r-cmd-check.yml
+++ b/inst/templates/call-r-cmd-check.yml
@@ -8,6 +8,12 @@ on:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines
   #schedule:
     #- cron: '0 0 * * 0'
+
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main

--- a/inst/templates/call-spell-check.yml
+++ b/inst/templates/call-spell-check.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: {}
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/spell-check.yml@main

--- a/inst/templates/call-update-pkgdown.yml
+++ b/inst/templates/call-update-pkgdown.yml
@@ -7,6 +7,12 @@ on:
   push:
     branches: [main, master]
     tags: ['*']
+
+# Give the fewest permissions possible. content is necessary.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  contents: write
+
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/update-pkgdown.yml@main


### PR DESCRIPTION
Addresses #184, #192, #188, and #177 (see commit messages for complete description). These are relatively small clean up changes. 

One change users will likely notice is that this PR makes it so all currently running actions of the same workflow on the same branch will be canceled when a new run is started. This is to stop unnecessary 
GitHub action runs which @kellijohnson-NOAA correctly pointed out happens all the time; a committer pushes up a changes, realized they need some additional change, and pushes up one more additional commit. The change will make it so that only the run with the *latest* commit will finish, and the other will be canceled. This seems like better default behavior, but we can make modifications if users disagree.
