### PR TITLE
fix spell-check.yml

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -90,6 +90,7 @@ jobs:
 
       - name: Save nrow_results to GITHUB_OUTPUT
         id: set_output
+        if: ${{ inputs.spell_check_additional_files }}
         run: |
           tmp_nrow_results=$(awk '{print int($1)}' nrow_results.txt)
           echo "nrow_results=$tmp_nrow_results" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Addresses issue #212 by saving GITHUB_OUTPUT only when additional files are being checked.

Tested with the FIMS repository:
- When `spell_check_additional_files` is `false`, the GHA ([log](https://github.com/NOAA-FIMS/FIMS/actions/runs/16453034760/job/46502956983)) skips the steps starting from `spelling::spell_check_files()`.
- When `spell_check_additional_files` is `true`, the GHA ([log](https://github.com/NOAA-FIMS/FIMS/actions/runs/16453203502/job/46503536520)) runs as expected and reports any spelling errors.