### PR TITLE
fix: add back use this as a needed dependency for doc and style

### DIFF
--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -85,6 +85,7 @@ jobs:
             remotes
             styler
             roxygen2
+            usethis
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         if: inputs.use-air == true
@@ -92,6 +93,7 @@ jobs:
           extra-packages: |
             remotes
             roxygen2
+            usethis
 
       - name: add ghactions4r, if using ghactions4r::rm_dollar_sign
         if: inputs.run-rm_dollar_sign == true 


### PR DESCRIPTION
usethis is needed for running usethis::use_tidy_description(); it was not caught because the testing I did already had use this as a dependency in the package.

I will merge this into main to hopefully fix the issue!