### PR TITLE
Allow multiple build triggers to work

### DIFF
--- a/R/use_r_workflows.R
+++ b/R/use_r_workflows.R
@@ -1,16 +1,17 @@
 #' Use workflow to run r cmd check on Linux, Mac, and Windows GitHub Actions
 #' @template workflow_name
-#' @param build_trigger Select the 
-#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
-#'  The default is to run on 
-#'  pushing commits to main (`push_to_main`). Other options are running
-#'  on pushing commits to any branch ("push_to_all_branches"); running when a 
-#'  pull request is opened, reopened, or updated (`pull_request`); 
-#'  running manually with the workflow_dispatch trigger (`manually`); 
-#'  and running  on the default branch (usually main) once a week (`weekly`).
-#'  Multiple build triggers are allowed; specify them as a vector. Note that
-#'  invalid build triggers will be silently removed as long as one build 
-#'  trigger is specified correctly.
+#' @param build_trigger Select the
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events). Options are:
+#' \describe{
+#'   \item{`push_to_main`}{Run on pushing commits to main (default)}
+#'   \item{`push_to_all_branches`}{Run on pushing commits to any branch}
+#'   \item{`pull_request`}{Run when a pull request is opened, reopened, or updated}
+#'   \item{`manually`}{Run manually with the workflow_dispatch trigger}
+#'   \item{`weekly`}{Run on the default branch (usually main) once a week}
+#' }
+#'  Multiple build triggers are allowed; specify them as a vector. Note that 
+#'  invalid build triggers will be silently removed as long as one build trigger 
+#'  is specified correctly.
 #' @param use_full_build_matrix Run R cmd check with two older versions of R in
 #'   addition to the three runs that use the release version.
 #' @param depends_on_tmb Adds an option that install Matrix from source for windows
@@ -114,12 +115,14 @@ use_r_cmd_check <- function(workflow_name = "call-r-cmd-check.yml",
 #' @template use_public_rspm
 #' @template depends_on_quarto
 #' @param build_trigger Select the 
-#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
-#'  The default is to run when a
-#'  pull request is opened, reopened, or updated (`pull_request`). Other
-#'  options are running on pushing commits to main (`push_to_main`); 
-#'  running on pushing commits to any branch (`push_to_all_branches`); 
-#'  and run manually with the workflow_dispatch trigger (`manually`). 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events). Options are:
+#' \describe{
+#'   \item{`pull_request`}{Run when a
+#'  pull request is opened, reopened, or updated (default)}
+#'   \item{`push_to_main`}{Run on pushing commits to main}
+#'   \item{`push_to_all_branches`}{Run on pushing commits to any branch}
+#'   \item{`manually`}{run manually with the workflow_dispatch trigger}
+#' }
 #'  Multiple build triggers are allowed; specify them as a vector. Note that 
 #'  invalid build triggers will be  silently removed as long as one build trigger 
 #'  is specified correctly.
@@ -212,13 +215,15 @@ use_calc_coverage <- function(workflow_name = "call-calc-coverage.yml", use_publ
 #' @template use_public_rspm
 #' @template depends_on_quarto
 #' @param build_trigger Select the 
-#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
-#'  The default is to run on pushing commits to main (`push_to_main`). Other
-#'  options are running on the default branch (usually main) once a week
-#'  (`weekly`) and running manually with the workflow_dispatch trigger 
-#'  (`manually`). Multiple build triggers are allowed; specify them as a
-#'  vector. Note that invalid build triggers will be 
-#'  silently removed as long as one build trigger is specified correctly.
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events). Options are:
+#' \describe{
+#'   \item{`push_to_main`}{Run on pushing commits to main (default)}
+#'   \item{`weekly`}{Run on the default branch (usually main) once a week}
+#'   \item{`manually`}{run manually with the workflow_dispatch trigger}
+#' }
+#'  Multiple build triggers are allowed; specify them as a vector. Note that 
+#'  invalid build triggers will be silently removed as long as one build trigger 
+#'  is specified correctly.
 #' @template tag_ghactions4r
 #' @export
 use_create_cov_badge <- function(
@@ -287,17 +292,18 @@ use_create_cov_badge <- function(
 #'  committed? Options are 1) in a pull request to the branch ("pull_request")
 #'  where the workflow started; or 2) directly to the branch ("directly") where
 #'  the workflow started.
-#' @param build_trigger Select the 
-#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
-#'  The default is to run on pushing commits to main (`push_to_main`}). Other
-#'  options are run when a pull request is
-#'  opened, reopened, or updated (`pull_request`); run when a comment containing
-#'  the command `\doc-and-style` is made on a pull request by people with write permissions
-#'  on the repository (`pr_comment`); running manually with the workflow_dispatch trigger 
-#'  (`manually`); and running on the default branch (usually main) once a week
-#'  (`weekly`). Multiple build triggers are allowed; specify them as a
-#'  vector. Note that invalid build triggers will be 
-#'  silently removed as long as one build trigger is specified correctly.
+#' @param build_trigger Select the
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events). Options are:
+#' \describe{
+#'   \item{`push_to_main`}{Run on pushing commits to main (default)}
+#'   \item{`pull_request`}{Run when a pull request is opened, reopened, or updated}
+#'   \item{`pr_comment`}{Run when a comment containing the command `\doc-and-style` is made on a pull request by people with write permissions on the repository}
+#'   \item{`manually`}{Run manually with the workflow_dispatch trigger}
+#'   \item{`weekly`}{Run on the default branch (usually main) once a week}
+#' }
+#'  Multiple build triggers are allowed; specify them as a vector. Note that 
+#'  invalid build triggers will be silently removed as long as one build trigger 
+#'  is specified correctly.
 #' @param use_air Use [air](https://posit-dev.github.io/air/) instead of [styler](https://styler.r-lib.org/) to style files? Defaults to FALSE.
 #' @param use_pat Should a personal access token (PAT) stored as a GitHub secret
 #'  be used? This is only necessary if you want the pull request generated by
@@ -412,13 +418,15 @@ use_doc_and_style_r <- function(workflow_name = "call-doc-and-style-r.yml",
 #' a branch called `gh-pages`.
 #' @template workflow_name
 #' @param build_trigger Select the 
-#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
-#'  The default is to run on pushing commits to main (`push_to_main`).
-#'  Other options are running on the default branch (usually main) once a week
-#'  (`weekly`) and running manually with the workflow_dispatch trigger 
-#'  (`manually`). Multiple build triggers are allowed; specify them as a
-#'  vector. Note that invalid build triggers will be 
-#'  silently removed as long as one build trigger is specified correctly.
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events). Options are:
+#' \describe{
+#'   \item{`push_to_main`}{Run on pushing commits to main (default)}
+#'   \item{`weekly`}{Run on the default branch (usually main) once a week}
+#'   \item{`manually`}{run manually with the workflow_dispatch trigger}
+#' }
+#'  Multiple build triggers are allowed; specify them as a vector. Note that 
+#'  invalid build triggers will be silently removed as long as one build trigger 
+#'  is specified correctly.
 #' @template tag_ghactions4r
 #' @inheritParams use_r_cmd_check
 #' @examples
@@ -474,16 +482,17 @@ use_update_pkgdown <- function(workflow_name = "call-update-pkgdown.yml",
 #' the site, and therefore can be used to test if the build is working in cases
 #' where you do not want to deploy as well.
 #' @template workflow_name
-#' @param build_trigger Select the 
-#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
-#'  The default is to run when a pull request is opened, reopened, or updated
-#'  (`pull_request`).Other options are running on pushing commits to 
-#'  main (`push_to_main`); running on pushing commits to any branch 
-#'  ("push_to_all_branches"); running manually with the workflow_dispatch 
-#'  trigger (`manually`); and running  on the default branch (usually
-#'  main) once a week (`weekly`). Multiple build triggers are allowed;
-#'  specify them as a vector. Note that invalid build triggers will be 
-#'  silently removed as long as one build trigger is specified correctly.
+#' @param build_trigger Select the
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events). Options are:
+#' \describe{
+#'   \item{`pull_request`}{Run when a pull request is opened, reopened, or updated (default)}
+#'   \item{`push_to_main`}{Run on pushing commits to main}
+#'   \item{`push_to_all_branches`}{Run on pushing commits to any branch}
+#'   \item{`manually`}{Run manually with the workflow_dispatch trigger}
+#'   \item{`weekly`}{Run on the default branch (usually main) once a week}
+#'  Multiple build triggers are allowed; specify them as a vector. Note that 
+#'  invalid build triggers will be silently removed as long as one build trigger 
+#'  is specified correctly.
 #' @template tag_ghactions4r
 #' @inheritParams use_r_cmd_check
 #' @examples
@@ -539,16 +548,7 @@ use_build_pkgdown <- function(workflow_name = "call-build-pkgdown.yml",
 #' the workflow will fail if any spelling errors are found. If set to "warning", the
 #' the workflow will pass even if spelling errors are found.
 #' @template workflow_name
-#' @param build_trigger Select the 
-#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
-#'  The default is to run when a pull request is opened, reopened, or updated
-#'  (`pull_request`).Other options are running on pushing commits to 
-#'  main (`push_to_main`); running on pushing commits to any branch 
-#'  ("push_to_all_branches"); running manually with the workflow_dispatch 
-#'  trigger (`manually`); and running  on the default branch (usually
-#'  main) once a week (`weekly`). Multiple build triggers are allowed;
-#'  specify them as a vector. Note that invalid build triggers will be 
-#'  silently removed as long as one build trigger is specified correctly.
+#' @inheritParams use_build_pkgdown
 #' @template tag_ghactions4r
 #' @export
 use_spell_check <- function(workflow_name = "call-spell-check.yml",

--- a/R/use_r_workflows.R
+++ b/R/use_r_workflows.R
@@ -1,6 +1,16 @@
 #' Use workflow to run r cmd check on Linux, Mac, and Windows GitHub Actions
 #' @template workflow_name
-#' @template build_trigger
+#' @param build_trigger Select the 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
+#'  The default is to run on 
+#'  pushing commits to main (`push_to_main`). Other options are running
+#'  on pushing commits to any branch ("push_to_all_branches"); running when a 
+#'  pull request is opened, reopened, or updated (`pull_request`); 
+#'  running manually with the workflow_dispatch trigger (`manually`); 
+#'  and running  on the default branch (usually main) once a week (`weekly`).
+#'  Multiple build triggers are allowed; specify them as a vector. Note that
+#'  invalid build triggers will be silently removed as long as one build 
+#'  trigger is specified correctly.
 #' @param use_full_build_matrix Run R cmd check with two older versions of R in
 #'   addition to the three runs that use the release version.
 #' @param depends_on_tmb Adds an option that install Matrix from source for windows
@@ -30,7 +40,7 @@
 #' }
 #' @export
 use_r_cmd_check <- function(workflow_name = "call-r-cmd-check.yml",
-                            build_trigger = c("push_to_main", "push_to_all_branches", "pull_request", "manually", "weekly"),
+                            build_trigger = "push_to_main",
                             use_full_build_matrix = FALSE,
                             depends_on_tmb = FALSE,
                             depends_on_quarto = FALSE,
@@ -38,12 +48,13 @@ use_r_cmd_check <- function(workflow_name = "call-r-cmd-check.yml",
                             tag_ghactions4r = NULL) {
   validate_additional_args(additional_args)
 
-  build_trigger <- tryCatch(match.arg(arg = build_trigger),
-    error = function(e) {
-      validate_build_trigger(build_trigger)
-      cli_abort(e)
-    }
-  )
+  build_trigger <- match.arg(arg = build_trigger,
+                             choices = c("push_to_main", 
+                                         "push_to_all_branches", 
+                                         "pull_request",
+                                         "manually",
+                                         "weekly"),
+                             several.ok = TRUE)
   check_workflow_name(workflow_name)
   if (use_full_build_matrix) {
     template_name <- "call-r-cmd-check-full.yml"
@@ -102,25 +113,30 @@ use_r_cmd_check <- function(workflow_name = "call-r-cmd-check.yml",
 #' @template workflow_name
 #' @template use_public_rspm
 #' @template depends_on_quarto
-#' @template build_trigger
+#' @param build_trigger Select the 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
+#'  The default is to run when a
+#'  pull request is opened, reopened, or updated (`pull_request`). Other
+#'  options are running on pushing commits to main (`push_to_main`); 
+#'  running on pushing commits to any branch (`push_to_all_branches`); 
+#'  and run manually with the workflow_dispatch trigger (`manually`). 
+#'  Multiple build triggers are allowed; specify them as a vector. Note that 
+#'  invalid build triggers will be  silently removed as long as one build trigger 
+#'  is specified correctly.
 #' @template tag_ghactions4r
 #' @export
 use_calc_cov_summaries <- function(
     workflow_name = "call-calc-cov-summaries.yml",
-    build_trigger = c(
-      "pull_request", "push_to_main", "push_to_all_branches",
-      "manually"
-    ),
+    build_trigger = "pull_request",
     use_public_rspm = TRUE,
     depends_on_quarto = FALSE,
     tag_ghactions4r = NULL) {
   check_workflow_name(workflow_name)
-  build_trigger <- tryCatch(match.arg(arg = build_trigger),
-    error = function(e) {
-      validate_build_trigger(build_trigger)
-      cli_abort(e)
-    }
-  )
+  build_trigger <- 
+    match.arg(arg = build_trigger, 
+              choices = c("pull_request", "push_to_main", "push_to_all_branches",
+                         "manually") ,
+              several.ok = TRUE)
 
 
   path_to_yml <- copy_caller_template(
@@ -130,7 +146,6 @@ use_calc_cov_summaries <- function(
   gha <- readLines(path_to_yml)
 
   gha <- add_build_trigger(build_trigger, gha)
-
   if (use_public_rspm == FALSE | depends_on_quarto == TRUE) {
     if (use_public_rspm == FALSE) {
       gha <- add_public_rspm_false(
@@ -196,21 +211,23 @@ use_calc_coverage <- function(workflow_name = "call-calc-coverage.yml", use_publ
 #' @template workflow_name
 #' @template use_public_rspm
 #' @template depends_on_quarto
-#' @template build_trigger
+#' @param build_trigger Select the 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
+#'  The default is to run on pushing commits to main (`push_to_main`). Other
+#'  options are running on the default branch (usually main) once a week
+#'  (`weekly`) and running manually with the workflow_dispatch trigger 
+#'  (`manually`). Multiple build triggers are allowed; specify them as a
+#'  vector. Note that invalid build triggers will be 
+#'  silently removed as long as one build trigger is specified correctly.
 #' @template tag_ghactions4r
 #' @export
 use_create_cov_badge <- function(
     workflow_name = "call-create-cov-badge.yml",
-    build_trigger = c("push_to_main", "weekly", "manually"),
+    build_trigger = "push_to_main",
     use_public_rspm = TRUE, depends_on_quarto = FALSE,
     tag_ghactions4r = NULL) {
   check_workflow_name(workflow_name)
-  build_trigger <- tryCatch(match.arg(arg = build_trigger),
-    error = function(e) {
-      validate_build_trigger(build_trigger)
-      cli_abort(e)
-    }
-  )
+  build_trigger <- match.arg(arg = build_trigger, choices = c("push_to_main", "weekly", "manually"), several.ok = TRUE)
   path_to_yml <- copy_caller_template(
     template_name = "call-create-cov-badge.yml",
     workflow_name = workflow_name
@@ -270,7 +287,17 @@ use_create_cov_badge <- function(
 #'  committed? Options are 1) in a pull request to the branch ("pull_request")
 #'  where the workflow started; or 2) directly to the branch ("directly") where
 #'  the workflow started.
-#' @template build_trigger
+#' @param build_trigger Select the 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
+#'  The default is to run on pushing commits to main (`push_to_main`}). Other
+#'  options are run when a pull request is
+#'  opened, reopened, or updated (`pull_request`); run when a comment containing
+#'  the command `\doc-and-style` is made on a pull request by people with write permissions
+#'  on the repository (`pr_comment`); running manually with the workflow_dispatch trigger 
+#'  (`manually`); and running on the default branch (usually main) once a week
+#'  (`weekly`). Multiple build triggers are allowed; specify them as a
+#'  vector. Note that invalid build triggers will be 
+#'  silently removed as long as one build trigger is specified correctly.
 #' @param use_air Use [air](https://posit-dev.github.io/air/) instead of [styler](https://styler.r-lib.org/) to style files? Defaults to FALSE.
 #' @param use_pat Should a personal access token (PAT) stored as a GitHub secret
 #'  be used? This is only necessary if you want the pull request generated by
@@ -316,13 +343,7 @@ use_create_cov_badge <- function(
 use_doc_and_style_r <- function(workflow_name = "call-doc-and-style-r.yml",
                                 use_rm_dollar_sign = FALSE,
                                 how_to_commit = c("pull_request", "directly"),
-                                build_trigger = c(
-                                  "push_to_main",
-                                  "pull_request",
-                                  "pr_comment",
-                                  "manually",
-                                  "weekly"
-                                ),
+                                build_trigger = "push_to_main",
                                 use_air = FALSE,
                                 use_pat = FALSE,
                                 pat_name = "PAT",
@@ -330,12 +351,14 @@ use_doc_and_style_r <- function(workflow_name = "call-doc-and-style-r.yml",
   # input checks
   check_workflow_name(workflow_name)
   how_to_commit <- match.arg(arg = how_to_commit)
-  build_trigger <- tryCatch(match.arg(arg = build_trigger),
-    error = function(e) {
-      validate_build_trigger(build_trigger)
-      cli_abort(e)
-    }
-  )
+  build_trigger <- match.arg(arg = build_trigger,
+                                      choices = c(
+                                                  "push_to_main",
+                                                  "pull_request",
+                                                  "pr_comment",
+                                                  "manually",
+                                                  "weekly"),
+                                      several.ok = TRUE)
   if (how_to_commit == "directly" & use_pat == TRUE) {
     stop("Using how_to_commit = 'directly' and use_pat = TRUE can lead to recursive runs.")
   }
@@ -388,7 +411,14 @@ use_doc_and_style_r <- function(workflow_name = "call-doc-and-style-r.yml",
 #' running this function. This workflow will assume the website is built from
 #' a branch called `gh-pages`.
 #' @template workflow_name
-#' @template build_trigger
+#' @param build_trigger Select the 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
+#'  The default is to run on pushing commits to main (`push_to_main`).
+#'  Other options are running on the default branch (usually main) once a week
+#'  (`weekly`) and running manually with the workflow_dispatch trigger 
+#'  (`manually`). Multiple build triggers are allowed; specify them as a
+#'  vector. Note that invalid build triggers will be 
+#'  silently removed as long as one build trigger is specified correctly.
 #' @template tag_ghactions4r
 #' @inheritParams use_r_cmd_check
 #' @examples
@@ -407,22 +437,16 @@ use_doc_and_style_r <- function(workflow_name = "call-doc-and-style-r.yml",
 #' }
 #' @export
 use_update_pkgdown <- function(workflow_name = "call-update-pkgdown.yml",
-                               build_trigger = c(
-                                 "push_to_main",
-                                 "manually",
-                                 "weekly"
-                               ),
+                               build_trigger = "push_to_main",
                                additional_args = NULL,
                                tag_ghactions4r = NULL) {
   build_trigger <- match.arg(
     arg = build_trigger,
     choices = c(
-      "push_to_main", "manually",
-      "weekly"
-    )
+      "push_to_main", "weekly", "manually"), 
+    several.ok = TRUE
   )
   validate_additional_args(additional_args)
-  validate_build_trigger(build_trigger)
   check_workflow_name(workflow_name)
   # get the template github action
   path_to_yml <- copy_caller_template(
@@ -450,7 +474,16 @@ use_update_pkgdown <- function(workflow_name = "call-update-pkgdown.yml",
 #' the site, and therefore can be used to test if the build is working in cases
 #' where you do not want to deploy as well.
 #' @template workflow_name
-#' @template build_trigger
+#' @param build_trigger Select the 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
+#'  The default is to run when a pull request is opened, reopened, or updated
+#'  (`pull_request`).Other options are running on pushing commits to 
+#'  main (`push_to_main`); running on pushing commits to any branch 
+#'  ("push_to_all_branches"); running manually with the workflow_dispatch 
+#'  trigger (`manually`); and running  on the default branch (usually
+#'  main) once a week (`weekly`). Multiple build triggers are allowed;
+#'  specify them as a vector. Note that invalid build triggers will be 
+#'  silently removed as long as one build trigger is specified correctly.
 #' @template tag_ghactions4r
 #' @inheritParams use_r_cmd_check
 #' @examples
@@ -469,19 +502,14 @@ use_update_pkgdown <- function(workflow_name = "call-update-pkgdown.yml",
 #' }
 #' @export
 use_build_pkgdown <- function(workflow_name = "call-build-pkgdown.yml",
-                              build_trigger = c(
-                                "pull_request", "push_to_main",
-                                "push_to_all_branches", "manually", "weekly"
-                              ),
+                              build_trigger = "pull_request",
                               additional_args = NULL,
                               tag_ghactions4r = NULL) {
   validate_additional_args(additional_args)
-  build_trigger <- tryCatch(match.arg(arg = build_trigger),
-    error = function(e) {
-      validate_build_trigger(build_trigger)
-      cli_abort(e)
-    }
-  )
+  build_trigger <- match.arg(arg = build_trigger, choices = c(
+                                "pull_request", "push_to_main",
+                                "push_to_all_branches", "manually", "weekly"
+                              ), several.ok = TRUE)
   check_workflow_name(workflow_name)
   path_to_yml <- copy_caller_template(
     template_name = "call-build-pkgdown.yml",
@@ -511,23 +539,27 @@ use_build_pkgdown <- function(workflow_name = "call-build-pkgdown.yml",
 #' the workflow will fail if any spelling errors are found. If set to "warning", the
 #' the workflow will pass even if spelling errors are found.
 #' @template workflow_name
-#' @template build_trigger
+#' @param build_trigger Select the 
+#'  [event that triggers the workflow](https://docs.github.com/en/actions/get-started/understand-github-actions#events).
+#'  The default is to run when a pull request is opened, reopened, or updated
+#'  (`pull_request`).Other options are running on pushing commits to 
+#'  main (`push_to_main`); running on pushing commits to any branch 
+#'  ("push_to_all_branches"); running manually with the workflow_dispatch 
+#'  trigger (`manually`); and running  on the default branch (usually
+#'  main) once a week (`weekly`). Multiple build triggers are allowed;
+#'  specify them as a vector. Note that invalid build triggers will be 
+#'  silently removed as long as one build trigger is specified correctly.
 #' @template tag_ghactions4r
 #' @export
 use_spell_check <- function(workflow_name = "call-spell-check.yml",
-                            build_trigger = c(
-                              "pull_request", "push_to_main",
-                              "push_to_all_branches", "weekly", "manually"
-                            ),
+                            build_trigger = "pull_request",
                             spell_check_additional_files = FALSE,
                             spell_check_report_level = c("error", "warning"),
                             tag_ghactions4r = NULL) {
-  build_trigger <- tryCatch(match.arg(arg = build_trigger),
-    error = function(e) {
-      validate_build_trigger(build_trigger)
-      cli_abort(e)
-    }
-  )
+  build_trigger <- match.arg(arg = build_trigger, choices = c(
+                              "pull_request", "push_to_main",
+                              "push_to_all_branches", "manually", "weekly"
+                            ), several.ok = TRUE)
   # Remind users that spell_check_report_level is set to 'error' by default if users
   # don't specify spell_check_report_level
   if (spell_check_additional_files == TRUE & length(spell_check_report_level) > 1) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -168,6 +168,7 @@ tryCatch
 ubuntu
 uncomment
 unlink
+unlist
 usethis
 vapply
 wd

--- a/tests/testthat/_snaps/use_r_workflows.md
+++ b/tests/testthat/_snaps/use_r_workflows.md
@@ -455,22 +455,23 @@
        [3] "# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows"
        [4] "on:"                                                                                                                                      
        [5] "  push:"                                                                                                                                  
-       [6] "    branches: [main]"                                                                                                                     
-       [7] ""                                                                                                                                         
-       [8] "# no permissions are needed by the default github token for this workflow to "                                                            
-       [9] "# run, so don't pass any."                                                                                                                
-      [10] "# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token"         
-      [11] "permissions: {}"                                                                                                                          
-      [12] ""                                                                                                                                         
-      [13] "jobs:"                                                                                                                                    
-      [14] "  call-workflow:"                                                                                                                         
-      [15] "    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main"                                                                    
-      [16] "    with:"                                                                                                                                
-      [17] "      additional_args_macos: |"                                                                                                           
-      [18] "        brew install curl"                                                                                                                
-      [19] "      use_full_build_matrix: true"                                                                                                        
+       [6] "  pull_request:"                                                                                                                          
+       [7] "  workflow_dispatch:"                                                                                                                     
+       [8] ""                                                                                                                                         
+       [9] "# no permissions are needed by the default github token for this workflow to "                                                            
+      [10] "# run, so don't pass any."                                                                                                                
+      [11] "# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token"         
+      [12] "permissions: {}"                                                                                                                          
+      [13] ""                                                                                                                                         
+      [14] "jobs:"                                                                                                                                    
+      [15] "  call-workflow:"                                                                                                                         
+      [16] "    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main"                                                                    
+      [17] "    with:"                                                                                                                                
+      [18] "      additional_args_macos: |"                                                                                                           
+      [19] "        brew install curl"                                                                                                                
+      [20] "      use_full_build_matrix: true"                                                                                                        
 
-# use_calc_cov_summaries() works
+# use_calc_cov_summaries() works and with specified multiple build triggers
 
     Code
       test
@@ -482,16 +483,18 @@
        [5] "name: call-calc-cov-summaries"                                                                                                            
        [6] "# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows"
        [7] "on:"                                                                                                                                      
-       [8] "  pull_request:"                                                                                                                          
-       [9] ""                                                                                                                                         
-      [10] "# limits permissions to write, as the common use case is for pull requests;"                                                              
-      [11] "# this means certain options may not work, but makes the workflow more secure"                                                            
-      [12] "permissions:"                                                                                                                             
-      [13] "  pull-requests: write"                                                                                                                   
-      [14] ""                                                                                                                                         
-      [15] "jobs:"                                                                                                                                    
-      [16] "  call-workflow:"                                                                                                                         
-      [17] "    uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main"                                                             
+       [8] "  push:"                                                                                                                                  
+       [9] "    branches: [main]"                                                                                                                     
+      [10] "  workflow_dispatch:"                                                                                                                     
+      [11] ""                                                                                                                                         
+      [12] "# limits permissions to write, as the common use case is for pull requests;"                                                              
+      [13] "# this means certain options may not work, but makes the workflow more secure"                                                            
+      [14] "permissions:"                                                                                                                             
+      [15] "  pull-requests: write"                                                                                                                   
+      [16] ""                                                                                                                                         
+      [17] "jobs:"                                                                                                                                    
+      [18] "  call-workflow:"                                                                                                                         
+      [19] "    uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main"                                                             
 
 ---
 
@@ -2339,16 +2342,14 @@
       [13] "  call-workflow:"                                                                                                                         
       [14] "    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main"                                                                    
 
-# use_doc_and_style_r() errors when multiple build triggers selected
+# use_doc_and_style_r() errors when an incorrect build triggers is selected
 
     Code
-      use_doc_and_style_r(workflow_name = "doc_style_mult_triggers.yml",
-        build_trigger = c("manually", "pull_request"))
+      use_doc_and_style_r(workflow_name = "doc_style_wrong_triggers.yml",
+        build_trigger = c("incorrect_build_trigger"))
     Condition
-      Error in `validate_build_trigger()`:
-      ! `build_trigger` must be be a vector of length 1.
-      i Multiple build triggers are not yet implemented.
-      x There are 2 elements.
+      Error in `match.arg()`:
+      ! 'arg' should be one of "push_to_main", "pull_request", "pr_comment", "manually", "weekly"
 
 # use_update_pkgdown()) works
 

--- a/tests/testthat/test-use_r_workflows.R
+++ b/tests/testthat/test-use_r_workflows.R
@@ -88,6 +88,7 @@ test_that("use_r_cmd_check() works with additional_args mac only", {
   path <- file.path(".github", "workflows", name)
   use_r_cmd_check(
     workflow_name = name,
+    build_trigger = c("push_to_all_branches", "pull_request", "manually"),
     use_full_build_matrix = TRUE,
     depends_on_tmb = FALSE,
     additional_args = list(
@@ -125,8 +126,8 @@ test_that("use_r_cmd_check() doesn't work with invalid additional_args", {
   )
 })
 
-test_that("use_calc_cov_summaries() works", {
-  use_calc_cov_summaries()
+test_that("use_calc_cov_summaries() works and with specified multiple build triggers", {
+  use_calc_cov_summaries(build_trigger = c("push_to_main", "manually"))
   expect_true(file.exists(".github/workflows/call-calc-cov-summaries.yml"))
   test <- readLines(".github/workflows/call-calc-cov-summaries.yml")
   expect_snapshot(test)
@@ -135,6 +136,7 @@ test_that("use_calc_cov_summaries() works", {
   test_octoyml <- readLines(".octocov.yml")
   expect_snapshot(test_octoyml)
 })
+
 
 test_that("use_calc_cov_summaries() works with use_public_rspm = FALSE", {
   workflow_name <- "call-calc-cov-summaries-false.yml"
@@ -326,10 +328,10 @@ test_that("use_doc_and_style_r() errors when a bad combo", {
 })
 
 # This currently is expected behavior.
-test_that("use_doc_and_style_r() errors when multiple build triggers selected", {
+test_that("use_doc_and_style_r() errors when an incorrect build triggers is selected", {
   expect_snapshot(use_doc_and_style_r(
-    workflow_name = "doc_style_mult_triggers.yml",
-    build_trigger = c("manually", "pull_request")
+    workflow_name = "doc_style_wrong_triggers.yml",
+    build_trigger = c("incorrect_build_trigger")
   ), error = TRUE)
 })
 


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.

The following individuals are available to review ghactions4r pull requests, so please select one of them as the reviewer and ask directly on the pull request (using `@mention`) if they are comfortable reviewing and provide a date you would like the review by.

 k-doering-NOAA Bai-Li-NOAA kellijohnson-NOAA Andrea-Havron-NOAA Schiano-NOAA msupernaw e-perl-NOAA ClaireGonzales-NOAA
-->

Closes #135. This changes the code so that only one build trigger option can be selected to allowing multiple to be selected in the template ghactions4r caller workflow files.

@ClaireGonzales-NOAA would you be interested in reviewing this within the next week? The changes are all in the R code.